### PR TITLE
Constrain plant name

### DIFF
--- a/BloomBuddyMobile/ViewModel/HouseholdViewModel.swift
+++ b/BloomBuddyMobile/ViewModel/HouseholdViewModel.swift
@@ -74,6 +74,10 @@ class HouseholdViewModel: ObservableObject {
             throw PropertyError.outOfRange("You can only have up to 5 plants!")
         }
         
+        guard (4...32).contains(nameToAdd.count) else {
+            throw PropertyError.outOfRange("Your plant name needs to be between 4 and 32 characters!")
+        }
+        
         guard !household.plants.contains(nameToAdd) else {
             throw PropertyError.alreadyExists("Plant with name \(nameToAdd) already exists!")
         }


### PR DESCRIPTION
This constraint is never mentioned in an issue, but it is really bad practice to allow users to just input a string of any length. I believe this should have been mentioned in issue #4 or #2. 

## 🧙🏻‍♂️ Describe your changes

- Constrain plant name to 4<=name.count<=32 characters

## 🔗 Issue that is implemented here 

N.A.

## 📸 Screenshot or screen recording of working solution

N.A.

## 👮🏻‍♂️ Check yourself

- [x] I have performed a self-review of my code
- [x] I have resolved all TODOs in this branch
- [x] Changes are covered by unit tests
